### PR TITLE
remove dynamic callable

### DIFF
--- a/AEPRulesEngine.podspec
+++ b/AEPRulesEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPRulesEngine"
-  s.version          = "1.0.0"
+  s.version          = "1.0.1"
   s.summary          = "AEPRulesEngine"
   s.description      = <<-DESC
                       A simple, generic, extensible Rules Engine in Swift

--- a/Sources/AEPRulesEngine/Expression/ComparisonExpression.swift
+++ b/Sources/AEPRulesEngine/Expression/ComparisonExpression.swift
@@ -28,8 +28,8 @@ public struct ComparisonExpression<A, B>: Evaluable {
 
     public func evaluate(in context: Context) -> Result<Bool, RulesFailure> {
         Log.trace(label: LOG_TAG, "Evaluating \(lhs) - \(operationName) - \(rhs)")
-        let resolvedLhs = lhs(context)
-        let resolvedRhs = rhs(context)
+        let resolvedLhs = lhs.resolve(in: context)
+        let resolvedRhs = rhs.resolve(in: context)
         var result: Result<Bool, RulesFailure>
         if let resolvedLhs_ = resolvedLhs, let resolvedRhs_ = resolvedRhs {
             result = context.evaluator.evaluate(operation: operationName, lhs: resolvedLhs_, rhs: resolvedRhs_)

--- a/Sources/AEPRulesEngine/Expression/Operand.swift
+++ b/Sources/AEPRulesEngine/Expression/Operand.swift
@@ -12,13 +12,12 @@
 
 import Foundation
 
-@dynamicCallable
 public enum Operand<T> {
     case none
     case some(T)
     case token(MustacheToken)
 
-    func dynamicallyCall(withArguments args: [Context]) -> T? {
+    func resolve(in context: Context) -> T? {
         switch self {
         case .none:
             return nil
@@ -26,7 +25,7 @@ public enum Operand<T> {
             return value
         case let .token(token):
 
-            if let result = token.resolve(in: args[0].transformer, data: args[0].data) {
+            if let result = token.resolve(in: context.transformer, data: context.data) {
                 return result as? T
             }
             return nil

--- a/Sources/AEPRulesEngine/Expression/UnaryExpression.swift
+++ b/Sources/AEPRulesEngine/Expression/UnaryExpression.swift
@@ -24,7 +24,7 @@ public struct UnaryExpression<A>: Evaluable {
 
     public func evaluate(in context: Context) -> Result<Bool, RulesFailure> {
         Log.trace(label: LOG_TAG, "Evaluating \(operationName) - \(lhs)")
-        let resolvedLhs = lhs(context)
+        let resolvedLhs = lhs.resolve(in: context)
         if let resolvedLhs_ = resolvedLhs {
             return context.evaluator.evaluate(operation: operationName, lhs: resolvedLhs_)
         }

--- a/Sources/AEPRulesEngine/RulesEngine.swift
+++ b/Sources/AEPRulesEngine/RulesEngine.swift
@@ -15,7 +15,7 @@ import Foundation
 public typealias RulesTracer = (Bool, Rule, Context, RulesFailure?) -> Void
 
 public class RulesEngine<T: Rule> {
-    public let version = "1.0.0"
+    public let version = "1.0.1"
     let evaluator: Evaluating
     let transformer: Transforming
     var tracer: RulesTracer?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/adobe/aepsdk-core-ios/issues/589
`@dynamicCallable` is causing Swift compatibility issue 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
