### PR TITLE
Short circuit the and/or operators

### DIFF
--- a/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
+++ b/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
@@ -30,9 +30,8 @@ public struct LogicalExpression: Evaluable {
         switch operationName {
         case "and":
             for evaluable in operands {
-                let result = evaluable.evaluate(in: context)
                 // Exit if any evaluation fails
-                if case .failure(let failure) = result {
+                if case .failure(let failure) = evaluable.evaluate(in: context) {
                     return .failure(failure)
                 }
             }

--- a/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
+++ b/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
@@ -27,8 +27,6 @@ public struct LogicalExpression: Evaluable {
     }
 
     public func evaluate(in context: Context) -> Result<Bool, RulesFailure> {
-        var operandsResults = [Result<Bool, RulesFailure>]()
-        
         switch operationName {
         case "and":
             for evaluable in operands {
@@ -37,10 +35,10 @@ public struct LogicalExpression: Evaluable {
                 if case .failure(let failure) = result {
                     return .failure(failure)
                 }
-                operandsResults.append(result)
             }
             return .success(true)
         case "or":
+            var operandsResults = [Result<Bool, RulesFailure>]()
             for evaluable in operands {
                 let result = evaluable.evaluate(in: context)
                 // Succeed with any success

--- a/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
+++ b/Sources/AEPRulesEngine/Expression/LogicalExpression.swift
@@ -31,7 +31,7 @@ public struct LogicalExpression: Evaluable {
         case "and":
             for evaluable in operands {
                 // Exit if any evaluation fails
-                if case .failure(let failure) = evaluable.evaluate(in: context) {
+                if case let .failure(failure) = evaluable.evaluate(in: context) {
                     return .failure(.innerFailure(message: "`And` returns false", error: failure))
                 }
             }
@@ -41,9 +41,9 @@ public struct LogicalExpression: Evaluable {
             for evaluable in operands {
                 let result = evaluable.evaluate(in: context)
                 // Succeed with any success
-                if case .success(_) = result {
+                if case .success = result {
                     return .success(true)
-                } else if case .failure(let failure) = result {
+                } else if case let .failure(failure) = result {
                     failureResults.append(failure)
                 }
             }

--- a/Tests/AEPRulesEngineTests/UnitTests/ExpressionTests.swift
+++ b/Tests/AEPRulesEngineTests/UnitTests/ExpressionTests.swift
@@ -33,7 +33,7 @@ class ExpressionTests: XCTestCase {
         let evaluator = ConditionEvaluator(options: .defaultOptions)
 
         let a = ComparisonExpression(lhs: 3, operationName: "equals", rhs: 3)
-        let result = a.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = a.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 
@@ -43,17 +43,17 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let c = LogicalExpression(operationName: "and", operands: a, b)
-        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
-    
+
     func testAndFail() {
         let evaluator = ConditionEvaluator(options: .defaultOptions)
 
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abcd")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let c = LogicalExpression(operationName: "and", operands: a, b)
-        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertFalse(result.value)
     }
 
@@ -63,7 +63,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let c = LogicalExpression(operationName: "or", operands: a, b)
-        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 
@@ -73,7 +73,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let c = LogicalExpression(operationName: "or", operands: a, b)
-        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(!result.value)
     }
 
@@ -83,7 +83,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let c = LogicalExpression(operationName: "unkonwn", operands: a, b)
-        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(!result.value)
     }
 
@@ -173,7 +173,7 @@ class ExpressionTests: XCTestCase {
             true
         }
         let a = ComparisonExpression(lhs: "3", operationName: "equals", rhs: 3)
-        let result = a.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        let result = a.evaluate(in: Context(data: [String: String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 }

--- a/Tests/AEPRulesEngineTests/UnitTests/ExpressionTests.swift
+++ b/Tests/AEPRulesEngineTests/UnitTests/ExpressionTests.swift
@@ -33,7 +33,7 @@ class ExpressionTests: XCTestCase {
         let evaluator = ConditionEvaluator(options: .defaultOptions)
 
         let a = ComparisonExpression(lhs: 3, operationName: "equals", rhs: 3)
-        let result = a.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = a.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 
@@ -43,8 +43,18 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let c = LogicalExpression(operationName: "and", operands: a, b)
-        let result = c.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
+    }
+    
+    func testAndFail() {
+        let evaluator = ConditionEvaluator(options: .defaultOptions)
+
+        let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abcd")
+        let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
+        let c = LogicalExpression(operationName: "and", operands: a, b)
+        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
+        XCTAssertFalse(result.value)
     }
 
     func testOrSuccess() {
@@ -53,7 +63,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc")
         let c = LogicalExpression(operationName: "or", operands: a, b)
-        let result = c.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 
@@ -63,7 +73,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let c = LogicalExpression(operationName: "or", operands: a, b)
-        let result = c.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(!result.value)
     }
 
@@ -73,7 +83,7 @@ class ExpressionTests: XCTestCase {
         let a = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let b = ComparisonExpression(lhs: "abc", operationName: "equals", rhs: "abc1")
         let c = LogicalExpression(operationName: "unkonwn", operands: a, b)
-        let result = c.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = c.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(!result.value)
     }
 
@@ -163,7 +173,7 @@ class ExpressionTests: XCTestCase {
             true
         }
         let a = ComparisonExpression(lhs: "3", operationName: "equals", rhs: 3)
-        let result = a.evaluate(in: Context(data: [:], evaluator: evaluator, transformer: Transformer()))
+        let result = a.evaluate(in: Context(data: [String:String](), evaluator: evaluator, transformer: Transformer()))
         XCTAssertTrue(result.value)
     }
 }


### PR DESCRIPTION
#63  This is an optimization to our And/Or operators where 
1. For "And" we fail early without evaluating other conditions
2. For "Or" we succeed early without evaluating other conditions