### PR TITLE
Version bump to 1.2.3

### DIFF
--- a/AEPRulesEngine.podspec
+++ b/AEPRulesEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPRulesEngine"
-  s.version          = "1.2.2"
+  s.version          = "1.2.3"
   s.summary          = "AEPRulesEngine"
   s.description      = <<-DESC
                       A simple, generic, extensible Rules Engine in Swift

--- a/Sources/AEPRulesEngine/RulesEngine.swift
+++ b/Sources/AEPRulesEngine/RulesEngine.swift
@@ -15,7 +15,7 @@ import Foundation
 public typealias RulesTracer = (Bool, Rule, Context, RulesFailure?) -> Void
 
 public class RulesEngine<T: Rule> {
-    public let version = "1.2.2"
+    public let version = "1.2.3"
     let evaluator: Evaluating
     let transformer: Transforming
     var tracer: RulesTracer?


### PR DESCRIPTION
Version bump to 1.2.3 with the following:

* Optimize "and" operator to fail after first failure without evaluating other conditions
* Optimize "or" operator to succeed after first success without evaluating other conditions