### PR TITLE
Update rules engine to support iOS 11 minimum and bump major version

### DIFF
--- a/AEPRulesEngine.podspec
+++ b/AEPRulesEngine.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPRulesEngine"
-  s.version          = "1.2.3"
+  s.version          = "2.0.0"
   s.summary          = "AEPRulesEngine"
   s.description      = <<-DESC
                       A simple, generic, extensible Rules Engine in Swift
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc          = true
 
-  s.ios.deployment_target = '10.0'
-  s.tvos.deployment_target = '10.0'
+  s.ios.deployment_target = '11.0'
+  s.tvos.deployment_target = '11.0'
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Alternatively, if your project has a `Package.swift` file, you can add AEPRulesE
 
 ```
 dependencies: [
-    .package(url: "https://github.com/adobe/aepsdk-rulesengine-ios.git", .upToNextMajor(from: "1.2.0"))
+    .package(url: "https://github.com/adobe/aepsdk-rulesengine-ios.git", .upToNextMajor(from: "2.0.0"))
 ]
 ```
 

--- a/Script/test-SPM.sh
+++ b/Script/test-SPM.sh
@@ -20,7 +20,7 @@ let package = Package(
     name: \"TestProject\",
     defaultLocalization: \"en-US\",
     platforms: [
-        .iOS(.v10), .tvOS(.v10)
+        .iOS(.v11), .tvOS(.v11)
     ],
     products: [
         .library(

--- a/Script/test-podspec.sh
+++ b/Script/test-podspec.sh
@@ -17,7 +17,7 @@ swift package generate-xcodeproj
 # Create a Podfile with our pod as dependency.
 echo "
 target '$PROJECT_NAME' do
-  platform :ios, '10.0'
+  platform :ios, '11.0'
   use_frameworks!
   pod 'AEPRulesEngine', :path => '../'
 end
@@ -53,7 +53,7 @@ swift package generate-xcodeproj
 # Create a Podfile with our pod as dependency.
 echo "
 target '$PROJECT_NAME' do
-  platform :tvos, '10.0'
+  platform :tvos, '11.0'
   use_frameworks!
   pod 'AEPRulesEngine', :path => '../'
 end

--- a/Sources/AEPRulesEngine/RulesEngine.swift
+++ b/Sources/AEPRulesEngine/RulesEngine.swift
@@ -15,7 +15,7 @@ import Foundation
 public typealias RulesTracer = (Bool, Rule, Context, RulesFailure?) -> Void
 
 public class RulesEngine<T: Rule> {
-    public let version = "1.2.3"
+    public let version = "2.0.0"
     let evaluator: Evaluating
     let transformer: Transforming
     var tracer: RulesTracer?


### PR DESCRIPTION
Drop iOS 10 support as Xcode 14 enforces. Bump major version to 2.0.0